### PR TITLE
Fix #13067

### DIFF
--- a/engine/classes/Elgg/Users/Accounts.php
+++ b/engine/classes/Elgg/Users/Accounts.php
@@ -256,10 +256,6 @@ class Accounts {
 			throw new RegistrationException($this->translator->translate('registration:invalidchars'));
 		}
 
-		// Belts and braces
-		// @todo Tidy into main unicode
-		$blacklist2 = '\'/\\"*& ?#%^(){}[]~?<>;|¬`@+=,:';
-
 		$blacklist2 = $this->hooks->trigger(
 			'username:character_blacklist',
 			'user',
@@ -274,7 +270,12 @@ class Accounts {
 				throw new RegistrationException($msg);
 			}
 		}
-
+		
+		$whitelist = '/^([A-Za-z_0-9]+)$/i';
+		if (!preg_match($whitelist, $username)) {
+		      throw new RegistrationException($this->translator->translate('registration:invalidchars'));
+		}
+		
 		$result = $this->hooks->trigger(
 			'registeruser:validate:username',
 			'all',

--- a/engine/classes/Elgg/Users/Accounts.php
+++ b/engine/classes/Elgg/Users/Accounts.php
@@ -271,7 +271,7 @@ class Accounts {
 			}
 		}
 		
-		$whitelist = '/^([A-Za-z_0-9]+)$/i';
+		$whitelist = '/^([A-Za-z_0-9.-]+)$/i';
 		if (!preg_match($whitelist, $username)) {
 		    throw new RegistrationException($this->translator->translate('registration:badchars'));
 		}

--- a/engine/classes/Elgg/Users/Accounts.php
+++ b/engine/classes/Elgg/Users/Accounts.php
@@ -273,7 +273,7 @@ class Accounts {
 		
 		$whitelist = '/^([A-Za-z_0-9]+)$/i';
 		if (!preg_match($whitelist, $username)) {
-		      throw new RegistrationException($this->translator->translate('registration:invalidchars'));
+		    throw new RegistrationException($this->translator->translate('registration:badchars'));
 		}
 		
 		$result = $this->hooks->trigger(

--- a/languages/en.php
+++ b/languages/en.php
@@ -399,6 +399,7 @@ return array(
 	'registration:passwordtooshort' => 'The password must be a minimum of %u characters long.',
 	'registration:dupeemail' => 'This email address has already been registered.',
 	'registration:invalidchars' => 'Sorry, your username contains the character %s which is invalid. The following characters are invalid: %s',
+	'registration:badchars' => 'Sorry, your username contains the invalid characters',
 	'registration:emailnotvalid' => 'Sorry, the email address you entered is invalid on this system',
 	'registration:passwordnotvalid' => 'Sorry, the password you entered is invalid on this system',
 	'registration:usernamenotvalid' => 'Sorry, the username you entered is invalid on this system',


### PR DESCRIPTION
Proposes to use standard characters in the username (latin characters, digitals and underscore) instead of different variations which may also be unsafe.